### PR TITLE
Capture wheel_spun, winner_selected, team_deleted, mode_changed

### DIFF
--- a/src/features/wheel/components/wheel-canvas.tsx
+++ b/src/features/wheel/components/wheel-canvas.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import { motion, useAnimation } from 'framer-motion';
 import confetti from 'canvas-confetti';
+import { usePostHog } from 'posthog-js/react';
 import { useWheelSegments } from '../hooks';
 import { useAppStore } from '@/lib/store';
 import { Button } from '@/components/ui/button';
@@ -37,7 +38,8 @@ const HIGHLANDER_COLORS = [
 
 export function WheelCanvas() {
     const { segments } = useWheelSegments();
-    const { isSpinning, setIsSpinning, winner, setWinner, spinRequest, resetSpinRequest, helpOpen, isHighlanderMode, removeActiveSegment, resetHighlander, isDeathMode } = useAppStore();
+    const { isSpinning, setIsSpinning, winner, setWinner, spinRequest, resetSpinRequest, helpOpen, isHighlanderMode, removeActiveSegment, resetHighlander, isDeathMode, mode, activeTeamId } = useAppStore();
+    const posthog = usePostHog();
     const controls = useAnimation();
     const [rotation, setRotation] = useState(0);
 
@@ -46,6 +48,14 @@ export function WheelCanvas() {
 
         setIsSpinning(true);
         setWinner(null);
+
+        posthog.capture('wheel_spun', {
+            team_id: mode === 'team' ? activeTeamId : null,
+            mode,
+            member_count: segments.length,
+            highlander_mode: isHighlanderMode,
+            death_mode: isDeathMode,
+        });
 
         // Calculate random spin
         const minSpins = 3;
@@ -85,7 +95,7 @@ export function WheelCanvas() {
                 removeActiveSegment(winner.id, winner.text);
             }
         }
-    }, [isSpinning, segments, rotation, controls, setIsSpinning, setWinner, helpOpen, isHighlanderMode, removeActiveSegment]);
+    }, [isSpinning, segments, rotation, controls, setIsSpinning, setWinner, helpOpen, isHighlanderMode, removeActiveSegment, isDeathMode, mode, activeTeamId, posthog]);
 
     // Listen for external spin requests
     useEffect(() => {

--- a/src/features/wheel/components/wheel-controller.tsx
+++ b/src/features/wheel/components/wheel-controller.tsx
@@ -48,11 +48,27 @@ export function WheelController() {
     }), [teams, adHocOrder]);
 
     const handleSelectTeam = (team: Team) => {
+        if (mode !== 'team' || activeTeamId !== team.id) {
+            if (mode !== 'team') {
+                posthog.capture('mode_changed', {
+                    from_mode: mode,
+                    to_mode: 'team',
+                    team_id: team.id,
+                });
+            }
+        }
         setActiveTeamId(team.id);
         setMode('team');
     };
 
     const handleSelectAdHoc = () => {
+        if (mode !== 'adhoc') {
+            posthog.capture('mode_changed', {
+                from_mode: mode,
+                to_mode: 'adhoc',
+                team_id: null,
+            });
+        }
         setMode('adhoc');
         setActiveTeamId(null);
     };
@@ -93,14 +109,28 @@ export function WheelController() {
         if (nextIndex !== -1 && nextIndex !== currentIndex) {
             const nextItem = items[nextIndex];
             if (nextItem.type === 'adhoc') {
+                if (mode !== 'adhoc') {
+                    posthog.capture('mode_changed', {
+                        from_mode: mode,
+                        to_mode: 'adhoc',
+                        team_id: null,
+                    });
+                }
                 setMode('adhoc');
                 setActiveTeamId(null);
             } else {
+                if (mode !== 'team') {
+                    posthog.capture('mode_changed', {
+                        from_mode: mode,
+                        to_mode: 'team',
+                        team_id: nextItem.id,
+                    });
+                }
                 setMode('team');
                 setActiveTeamId(nextItem.id);
             }
         }
-    }, [mode, activeTeamId, items, setMode, setActiveTeamId]);
+    }, [mode, activeTeamId, items, setMode, setActiveTeamId, posthog]);
 
     // Keyboard shortcuts
     useEffect(() => {
@@ -148,6 +178,11 @@ export function WheelController() {
     const handleDelete = async (team: Team) => {
         if (confirm(`Are you sure you want to delete ${team.name}?`)) {
             await deleteTeam(team.id);
+            posthog.capture('team_deleted', {
+                team_id: team.id,
+                team_name: team.name,
+                member_count: team.members.length,
+            });
             if (activeTeamId === team.id) {
                 setActiveTeamId(null);
                 setMode('adhoc');
@@ -156,9 +191,6 @@ export function WheelController() {
     };
 
     const handleSubmit = async (data: CreateTeamInput) => {
-        // Analytics: Track team interaction
-
-
         if (editingTeam) {
             const membersWithIds = data.members.map(m => ({
                 id: uuidv4(),

--- a/src/features/wheel/components/winner-modal.tsx
+++ b/src/features/wheel/components/winner-modal.tsx
@@ -28,6 +28,18 @@ export function WinnerModal() {
     }, [setWinner]);
 
     useEffect(() => {
+        if (winner) {
+            posthog.capture('winner_selected', {
+                team_id: mode === 'team' ? activeTeamId : null,
+                mode,
+                winner_name: winner,
+                highlander_mode: isHighlanderMode,
+                death_mode: isDeathMode,
+            });
+        }
+    }, [winner, mode, activeTeamId, isHighlanderMode, isDeathMode, posthog]);
+
+    useEffect(() => {
         if (winner && !isHighlanderMode) { // No confetti for eliminations
             // Default confetti colors
             let colors = ['#26ccff', '#a25afd', '#ff5e7e', '#88ff5a', '#fcff42', '#ffa62d', '#ff36ff'];


### PR DESCRIPTION
## Summary
- `WheelCanvas` now captures `wheel_spun` with `team_id`, `mode`, `member_count`, `highlander_mode`, `death_mode`.
- `WinnerModal` now captures `winner_selected` with `team_id`, `mode`, `winner_name`, `highlander_mode`, `death_mode` (fires for both regular wins and Highlander eliminations).
- `WheelController` now captures `team_deleted` on delete and `mode_changed` whenever the active list switches between `team` and `adhoc` (via click or keyboard nav). The stale `// Analytics: Track team interaction` placeholder is removed.

This rounds out the `team_created → wheel_spun → winner_selected` activation funnel and gives us spins/day, spins/team, winner outcomes, and Highlander/Death Mode adoption.

Note: `excluded_count` was not added — the store mutates the active member list rather than tracking exclusions separately, so `member_count` already reflects remaining segments. We can revisit if we add an "original count" field.

## Test plan
- [ ] Run `pnpm dev`, open PostHog devtools / network filter `/e/`.
- [ ] Create team → existing `team_created` still fires.
- [ ] Click team / adhoc → `mode_changed` fires once per real switch (not on re-select).
- [ ] Use ↑/↓ keyboard nav → `mode_changed` fires when crossing between team and adhoc.
- [ ] Spin wheel → `wheel_spun` event with correct properties.
- [ ] Wait for winner modal → `winner_selected` with `winner_name`.
- [ ] Toggle Highlander and Death Mode and re-spin → flag values reflected on both events.
- [ ] Delete team → `team_deleted` event.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*