### PR TITLE
fix(logger): always emit errors to console and PostHog

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,6 +1,19 @@
+import { posthog } from './posthog';
 import { useAppStore } from './store';
 
 const isVerbose = () => useAppStore.getState().verboseLogging;
+
+const reportException = (args: unknown[]) => {
+    if (typeof window === 'undefined') return;
+    try {
+        const errorArg = args.find((a): a is Error => a instanceof Error);
+        const extras = args.filter(a => a !== errorArg);
+        const exception = errorArg ?? new Error(args.map(a => String(a)).join(' ') || 'Logger.error called');
+        posthog.captureException(exception, extras.length ? { extra: extras } : undefined);
+    } catch {
+        // Never let telemetry failures mask the original error.
+    }
+};
 
 export const Logger = {
     log: (...args: unknown[]) => {
@@ -14,11 +27,8 @@ export const Logger = {
         }
     },
     error: (...args: unknown[]) => {
-        // Errors might be critical, but the user asked to "hide everything" behind the flag.
-        // I will respect the flag for errors too as per instruction "hide everything".
-        if (isVerbose()) {
-            console.error(...args);
-        }
+        console.error(...args);
+        reportException(args);
     },
     info: (...args: unknown[]) => {
         if (isVerbose()) {


### PR DESCRIPTION
## Summary
- `Logger.error` in `src/lib/logger.ts` was gated behind the `verboseLogging` Zustand flag (off by default in production), silently swallowing every error from import-service, export-service, the import-team-modal flow, the Slack-driven paths, and remote-team updates.
- Always emit errors to `console.error`, regardless of the flag.
- Route the same call through `posthog.captureException` so errors surface in PostHog Error Tracking. Telemetry is wrapped in try/catch and guarded by `typeof window` so it can never mask the original error or break SSR.
- `verboseLogging` keeps its role for `log`/`warn`/`info`/`debug` diagnostic output only.

The four catch blocks called out in the issue (`import-service.ts:58`, `import-team-modal.tsx:38`/`:117`, `teams/hooks.ts:62`) already pass the raw error to `Logger.error`, so they automatically benefit — no changes needed there.

## Test plan
- [ ] `npm run build` clean
- [ ] With `verboseLogging=false` (default), trigger an import failure and confirm the error appears in the browser console
- [ ] Confirm `$exception` event appears in PostHog Error Tracking (project 99423)
- [ ] Toggle `verboseLogging=true` and confirm `Logger.log/info/warn/debug` resume output with no duplicate error logs
- [ ] SSR sanity: any module importing Logger does not throw on the server

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*