### PR TITLE
feat: add product tour for new users

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "clsx": "^2.1.1",
         "dexie": "^4.2.1",
         "dexie-react-hooks": "^4.2.0",
+        "driver.js": "^1.4.0",
         "framer-motion": "^12.23.24",
         "lucide-react": "^0.555.0",
         "next": "^16.0.10",
@@ -3241,6 +3242,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/driver.js": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/driver.js/-/driver.js-1.4.0.tgz",
+      "integrity": "sha512-Gm64jm6PmcU+si21sQhBrTAM1JvUrR0QhNmjkprNLxohOBzul9+pNHXgQaT9lW84gwg9GMLB3NZGuGolsz5uew==",
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "clsx": "^2.1.1",
     "dexie": "^4.2.1",
     "dexie-react-hooks": "^4.2.0",
+    "driver.js": "^1.4.0",
     "framer-motion": "^12.23.24",
     "lucide-react": "^0.555.0",
     "next": "^16.0.10",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Outfit, Inter } from "next/font/google";
 import localFont from "next/font/local";
 import "./globals.css";
+import "driver.js/dist/driver.css";
 import { PostHogProvider } from "./providers/posthog-provider";
 
 const outfit = Outfit({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,6 +13,7 @@ import { HighlanderModeToggle } from '@/components/highlander-mode-toggle';
 import { usePostHog } from 'posthog-js/react';
 import { RemoteTeamsInitializer } from '@/features/teams/components/remote-teams-initializer';
 import { useWheelSegments } from '@/features/wheel/hooks';
+import { TourRunner } from '@/features/tour/tour-runner';
 
 export default function Home() {
   const { helpOpen, setHelpOpen, adminOpen, setAdminOpen, isHighlanderMode, isDeathMode } = useAppStore();
@@ -34,6 +35,7 @@ export default function Home() {
   return (
     <main className={`min-h-screen p-8 transition-colors duration-300 relative isolate ${isHighlanderMode && !isDeathMode ? 'bg-blue-950 text-blue-100' : ''} ${isHighlanderMode ? 'font-[family-name:var(--font-highlander)]' : ''}`}>
       <RemoteTeamsInitializer />
+      <TourRunner />
 
       {isDeathMode && (
         <div className="fixed inset-0 -z-10 overflow-hidden pointer-events-none">
@@ -59,19 +61,19 @@ export default function Home() {
 
         {/* Header */}
         <header className="flex justify-between items-center">
-          <h1 className={`text-5xl font-bold tracking-widest ${isHighlanderMode ? 'font-[family-name:var(--font-highlander)]' : 'font-heading'} ${isDeathMode ? 'text-gray-400 drop-shadow-[0_0_15px_rgba(220,38,38,0.8)]' : (isHighlanderMode ? 'text-blue-300 drop-shadow-[0_0_10px_rgba(59,130,246,0.8)]' : '')}`}>
+          <h1 data-tour-id="app-title" className={`text-5xl font-bold tracking-widest ${isHighlanderMode ? 'font-[family-name:var(--font-highlander)]' : 'font-heading'} ${isDeathMode ? 'text-gray-400 drop-shadow-[0_0_15px_rgba(220,38,38,0.8)]' : (isHighlanderMode ? 'text-blue-300 drop-shadow-[0_0_10px_rgba(59,130,246,0.8)]' : '')}`}>
             {isHighlanderMode ? (isDeathMode ? 'Highlander of Death' : 'Highlander Mode') : (isDeathMode ? 'Wheel of Death' : 'Wheel of Names')}
           </h1>
           <div className="flex items-center gap-2">
-            <HighlanderModeToggle />
-            <DeathModeToggle />
+            <div data-tour-id="highlander-toggle"><HighlanderModeToggle /></div>
+            <div data-tour-id="death-toggle"><DeathModeToggle /></div>
             {/* Settings button */}
-            <Button variant="ghost" size="icon" onClick={() => setAdminOpen(true)} title="Settings" className={isDeathMode ? 'text-gray-400 hover:text-gray-300' : ''}>
+            <Button data-tour-id="settings-button" variant="ghost" size="icon" onClick={() => setAdminOpen(true)} title="Settings" className={isDeathMode ? 'text-gray-400 hover:text-gray-300' : ''}>
               <span className="sr-only">Settings</span>
               <Settings className="h-5 w-5" />
             </Button>
             {/* Help button */}
-            <Button variant="ghost" size="icon" onClick={() => setHelpOpen(true)} title="Help" className={isDeathMode ? 'text-gray-400 hover:text-gray-300' : ''}>
+            <Button data-tour-id="help-button" variant="ghost" size="icon" onClick={() => setHelpOpen(true)} title="Help" className={isDeathMode ? 'text-gray-400 hover:text-gray-300' : ''}>
               <span className="sr-only">Help</span>
               <HelpCircle className="h-5 w-5" />
             </Button>
@@ -82,12 +84,12 @@ export default function Home() {
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-8">
 
           {/* Left Column: Wheel */}
-          <div className={`lg:col-span-7 rounded-[var(--radius)] p-8 flex items-center justify-center min-h-[400px] border-2 border-dashed backdrop-blur-sm ${isDeathMode ? 'bg-black/30 border-red-900 shadow-[0_0_30px_rgba(220,38,38,0.3)] z-10' : (isHighlanderMode ? 'bg-blue-900/30 border-blue-500/50 shadow-[0_0_30px_rgba(30,58,138,0.5)] z-10' : 'bg-muted/30 border-border')}`}>
+          <div data-tour-id="wheel-column" className={`lg:col-span-7 rounded-[var(--radius)] p-8 flex items-center justify-center min-h-[400px] border-2 border-dashed backdrop-blur-sm ${isDeathMode ? 'bg-black/30 border-red-900 shadow-[0_0_30px_rgba(220,38,38,0.3)] z-10' : (isHighlanderMode ? 'bg-blue-900/30 border-blue-500/50 shadow-[0_0_30px_rgba(30,58,138,0.5)] z-10' : 'bg-muted/30 border-border')}`}>
             <WheelCanvas />
           </div>
 
           {/* Right Column: Controls & Teams */}
-          <div className="lg:col-span-5">
+          <div data-tour-id="team-controller" className="lg:col-span-5">
             <WheelController />
           </div>
         </div>

--- a/src/features/help/components/HelpModal.tsx
+++ b/src/features/help/components/HelpModal.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 
 import { usePostHog } from 'posthog-js/react';
+import { useTour } from '@/features/tour/use-tour';
 
 interface HelpModalProps {
     open: boolean;
@@ -12,6 +13,13 @@ interface HelpModalProps {
 export function HelpModal({ open, onOpenChange }: HelpModalProps) {
     const posthog = usePostHog();
     const isDeathMode = posthog.isFeatureEnabled('death_mode');
+    const { startTour } = useTour();
+
+    const handleTakeTour = () => {
+        onOpenChange(false);
+        // Allow the modal close animation to finish so anchors are visible/unblocked.
+        setTimeout(() => startTour({ source: 'manual' }), 150);
+    };
 
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
@@ -43,7 +51,10 @@ export function HelpModal({ open, onOpenChange }: HelpModalProps) {
                         </a>.
                     </p>
                 </div>
-                <div className="mt-6 flex justify-end">
+                <div className="mt-6 flex justify-end gap-2">
+                    <Button variant="outline" onClick={handleTakeTour}>
+                        Take the tour
+                    </Button>
                     <Button variant="ghost" onClick={() => onOpenChange(false)}>
                         Close
                     </Button>

--- a/src/features/tour/post-spin-tip.tsx
+++ b/src/features/tour/post-spin-tip.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Lightbulb, X } from 'lucide-react';
+import { POST_SPIN_TIP_KEY } from './tour-steps';
+
+interface PostSpinTipProps {
+    isHighlanderMode: boolean;
+    isDeathMode: boolean;
+}
+
+export function PostSpinTip({ isHighlanderMode, isDeathMode }: PostSpinTipProps) {
+    const [visible, setVisible] = useState(false);
+
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+        const seen = window.localStorage.getItem(POST_SPIN_TIP_KEY) === '1';
+        if (!seen) {
+            setVisible(true);
+            window.localStorage.setItem(POST_SPIN_TIP_KEY, '1');
+        }
+    }, []);
+
+    if (!visible) return null;
+
+    const tipText = isHighlanderMode
+        ? "In Highlander Mode, the winner is automatically eliminated. Keep spinning until one remains!"
+        : "Tip: open a team in the right column and click any name to exclude them from future spins.";
+
+    return (
+        <div
+            className={`relative mt-2 rounded-md border px-4 py-3 text-sm flex items-start gap-3 ${
+                isDeathMode
+                    ? 'bg-red-950/80 border-red-700 text-red-100'
+                    : 'bg-amber-50 border-amber-200 text-amber-900'
+            }`}
+            role="status"
+        >
+            <Lightbulb className="h-4 w-4 mt-0.5 shrink-0" />
+            <p className="flex-1">{tipText}</p>
+            <button
+                type="button"
+                onClick={() => setVisible(false)}
+                aria-label="Dismiss tip"
+                className="shrink-0 opacity-70 hover:opacity-100"
+            >
+                <X className="h-4 w-4" />
+            </button>
+        </div>
+    );
+}

--- a/src/features/tour/tour-runner.tsx
+++ b/src/features/tour/tour-runner.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useTour } from './use-tour';
+
+export function TourRunner() {
+    const { startTour, hasCompletedTour } = useTour();
+
+    useEffect(() => {
+        if (hasCompletedTour()) return;
+
+        const handle = window.setTimeout(() => {
+            if (!document.querySelector('[data-tour-id="app-title"]')) return;
+            startTour({ source: 'auto' });
+        }, 500);
+
+        return () => window.clearTimeout(handle);
+    }, [startTour, hasCompletedTour]);
+
+    return null;
+}

--- a/src/features/tour/tour-steps.ts
+++ b/src/features/tour/tour-steps.ts
@@ -1,0 +1,86 @@
+export interface TourStep {
+    id: string;
+    selector: string;
+    title: string;
+    description: string;
+    side?: 'left' | 'right' | 'top' | 'bottom' | 'over';
+    align?: 'start' | 'center' | 'end';
+}
+
+export const TOUR_STEPS: TourStep[] = [
+    {
+        id: 'app-title',
+        selector: '[data-tour-id="app-title"]',
+        title: 'Welcome to Wheel of Names',
+        description: "Let's take 30 seconds to show you around. Use Next and Prev to step through, or Skip to dismiss.",
+        side: 'bottom',
+        align: 'start',
+    },
+    {
+        id: 'spin-button',
+        selector: '[data-tour-id="spin-button"]',
+        title: 'Spin the wheel',
+        description: 'Click SPIN (or press Enter) to pick a random name from the wheel.',
+        side: 'top',
+        align: 'center',
+    },
+    {
+        id: 'team-controller',
+        selector: '[data-tour-id="team-controller"]',
+        title: 'Your lists',
+        description: 'Switch between saved teams and the Quick List here. Drag to reorder; click to select.',
+        side: 'left',
+        align: 'start',
+    },
+    {
+        id: 'new-team-button',
+        selector: '[data-tour-id="new-team-button"]',
+        title: 'Create a team',
+        description: "Click 'New Team' (or press N) to save a group of names you'll spin often.",
+        side: 'left',
+        align: 'center',
+    },
+    {
+        id: 'adhoc-input',
+        selector: '[data-tour-id="adhoc-input"]',
+        title: 'Or paste names ad-hoc',
+        description: 'Type or paste a comma-separated list here for one-off picks — no saving required.',
+        side: 'left',
+        align: 'center',
+    },
+    {
+        id: 'highlander-toggle',
+        selector: '[data-tour-id="highlander-toggle"]',
+        title: 'Highlander Mode',
+        description: 'Elimination round — each spin removes the winner until one remains. There can be only one!',
+        side: 'bottom',
+        align: 'end',
+    },
+    {
+        id: 'death-toggle',
+        selector: '[data-tour-id="death-toggle"]',
+        title: 'Death Mode',
+        description: 'A thematic reskin with flames and skulls. (Mutually exclusive with Highlander.)',
+        side: 'bottom',
+        align: 'end',
+    },
+    {
+        id: 'settings-button',
+        selector: '[data-tour-id="settings-button"]',
+        title: 'Settings',
+        description: 'Backup & restore your teams, manage integrations, and override feature flags.',
+        side: 'bottom',
+        align: 'end',
+    },
+    {
+        id: 'help-button',
+        selector: '[data-tour-id="help-button"]',
+        title: 'Help is always here',
+        description: 'Press ? or click this button anytime to see keyboard shortcuts and re-run this tour.',
+        side: 'bottom',
+        align: 'end',
+    },
+];
+
+export const TOUR_COMPLETED_KEY = 'wot_tour_completed_v1';
+export const POST_SPIN_TIP_KEY = 'wot_post_spin_tip_seen_v1';

--- a/src/features/tour/use-tour.ts
+++ b/src/features/tour/use-tour.ts
@@ -1,0 +1,119 @@
+'use client';
+
+import { useCallback, useRef } from 'react';
+import { driver, type Driver, type DriveStep } from 'driver.js';
+import { usePostHog } from 'posthog-js/react';
+import { TOUR_STEPS, TOUR_COMPLETED_KEY } from './tour-steps';
+
+export type TourSource = 'auto' | 'manual';
+
+interface StartTourOptions {
+    source: TourSource;
+}
+
+interface UseTourReturn {
+    startTour: (options: StartTourOptions) => void;
+    hasCompletedTour: () => boolean;
+}
+
+export function useTour(): UseTourReturn {
+    const posthog = usePostHog();
+    const driverRef = useRef<Driver | null>(null);
+    const sourceRef = useRef<TourSource>('auto');
+    const startedAtRef = useRef<number>(0);
+    const skippedRef = useRef<boolean>(false);
+    const lastStepIdRef = useRef<string>('');
+
+    const hasCompletedTour = useCallback(() => {
+        if (typeof window === 'undefined') return true;
+        return window.localStorage.getItem(TOUR_COMPLETED_KEY) === '1';
+    }, []);
+
+    const markCompleted = useCallback(() => {
+        if (typeof window !== 'undefined') {
+            window.localStorage.setItem(TOUR_COMPLETED_KEY, '1');
+        }
+    }, []);
+
+    const startTour = useCallback(({ source }: StartTourOptions) => {
+        if (driverRef.current?.isActive()) return;
+
+        sourceRef.current = source;
+        startedAtRef.current = Date.now();
+        skippedRef.current = false;
+        lastStepIdRef.current = TOUR_STEPS[0]?.id ?? '';
+
+        const steps: DriveStep[] = TOUR_STEPS.map((step) => ({
+            element: step.selector,
+            popover: {
+                title: step.title,
+                description: step.description,
+                side: step.side,
+                align: step.align,
+            },
+        }));
+
+        const instance = driver({
+            showProgress: true,
+            allowClose: true,
+            smoothScroll: true,
+            stagePadding: 6,
+            stageRadius: 8,
+            popoverClass: 'wot-tour-popover',
+            nextBtnText: 'Next',
+            prevBtnText: 'Back',
+            doneBtnText: 'Done',
+            steps,
+            onHighlightStarted: (_el, step, { driver: d }) => {
+                const index = d.getActiveIndex() ?? 0;
+                const stepConfig = TOUR_STEPS[index];
+                if (!stepConfig) return;
+                lastStepIdRef.current = stepConfig.id;
+                posthog.capture('product_tour_step_viewed', {
+                    step_id: stepConfig.id,
+                    step_index: index,
+                    total_steps: TOUR_STEPS.length,
+                    source: sourceRef.current,
+                });
+            },
+            onCloseClick: (_el, _step, { driver: d }) => {
+                skippedRef.current = true;
+                const index = d.getActiveIndex() ?? 0;
+                const stepConfig = TOUR_STEPS[index];
+                posthog.capture('product_tour_skipped', {
+                    step_id: stepConfig?.id ?? lastStepIdRef.current,
+                    step_index: index,
+                    total_steps: TOUR_STEPS.length,
+                    source: sourceRef.current,
+                });
+                d.destroy();
+            },
+            onDestroyed: () => {
+                markCompleted();
+                if (!skippedRef.current) {
+                    const completedAt = new Date().toISOString();
+                    posthog.capture('product_tour_completed', {
+                        source: sourceRef.current,
+                        duration_ms: Date.now() - startedAtRef.current,
+                        total_steps: TOUR_STEPS.length,
+                    });
+                    posthog.setPersonProperties?.({
+                        product_tour_completed_at: completedAt,
+                        product_tour_completed_source: sourceRef.current,
+                    });
+                }
+            },
+        });
+
+        driverRef.current = instance;
+
+        posthog.capture('product_tour_started', {
+            source,
+            total_steps: TOUR_STEPS.length,
+        });
+
+        instance.drive();
+    }, [posthog, markCompleted]);
+
+    return { startTour, hasCompletedTour };
+}

--- a/src/features/wheel/components/sortable-adhoc-item.tsx
+++ b/src/features/wheel/components/sortable-adhoc-item.tsx
@@ -32,7 +32,7 @@ export function SortableAdHocItem({ isActive, onSelect, onNavigateUp, onNavigate
     };
 
     return (
-        <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+        <div ref={setNodeRef} style={style} {...attributes} {...listeners} data-tour-id="adhoc-input">
             <div onClick={onSelect} className={styles['sortable-adhoc-item']}>
                 <div className={cn(
                     styles['sortable-adhoc-item__content'],

--- a/src/features/wheel/components/wheel-canvas.tsx
+++ b/src/features/wheel/components/wheel-canvas.tsx
@@ -259,6 +259,7 @@ export function WheelCanvas() {
                 </Button>
             ) : (
                 <Button
+                    data-tour-id="spin-button"
                     size="lg"
                     className={`text-xl px-12 py-8 rounded-full shadow-lg hover:scale-105 transition-transform ${isDeathMode ? 'bg-red-900 hover:bg-red-800 text-white border-2 border-red-500' : ''}`}
                     onClick={spinWheel}

--- a/src/features/wheel/components/wheel-controller.tsx
+++ b/src/features/wheel/components/wheel-controller.tsx
@@ -265,7 +265,7 @@ export function WheelController() {
                 )}>
                     Choose a List
                 </h2>
-                <Button onClick={handleCreate} size="sm">
+                <Button data-tour-id="new-team-button" onClick={handleCreate} size="sm">
                     <Plus className="mr-2 h-4 w-4" />
                     New Team
                 </Button>

--- a/src/features/wheel/components/winner-modal.tsx
+++ b/src/features/wheel/components/winner-modal.tsx
@@ -9,6 +9,7 @@ import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Trophy, Skull, User } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { PostSpinTip } from '@/features/tour/post-spin-tip';
 import styles from './winner-modal.module.css';
 
 export function WinnerModal() {
@@ -190,6 +191,9 @@ export function WinnerModal() {
                     >
                         {isHighlanderMode ? 'There can be only one!' : isDeathMode ? 'Accept Fate' : 'Awesome!'}
                     </Button>
+                    {winner && (
+                        <PostSpinTip isHighlanderMode={isHighlanderMode} isDeathMode={isDeathMode} />
+                    )}
                 </div>
             </DialogContent>
         </Dialog>


### PR DESCRIPTION
## Summary

- New `src/features/tour/` feature wiring up a multi-step product tour with [driver.js](https://driverjs.com): step config, a `useTour()` hook, an auto-start `TourRunner`, and a one-time post-spin tip in the winner modal.
- Tour walks new users through the title, SPIN button, team controller, New Team button, Quick List, Highlander Mode, Death Mode, Settings, and Help. Auto-runs on first visit (gated by `localStorage["wot_tour_completed_v1"]`) and is re-triggerable via a new **Take the tour** button in the Help modal.
- PostHog instrumentation: captures `product_tour_started` / `product_tour_step_viewed` / `product_tour_completed` / `product_tour_skipped`, plus a `product_tour_completed_at` person property on completion.

## What changed

- `src/features/tour/{tour-steps.ts, use-tour.ts, tour-runner.tsx, post-spin-tip.tsx}` — new feature.
- `src/app/layout.tsx` — imports `driver.js/dist/driver.css`.
- `src/app/page.tsx` — mounts `<TourRunner />` and adds `data-tour-id` anchors to header elements and the two main columns.
- `src/features/wheel/components/wheel-canvas.tsx` — `data-tour-id="spin-button"` on SPIN.
- `src/features/wheel/components/wheel-controller.tsx` — `data-tour-id="new-team-button"` on New Team.
- `src/features/wheel/components/sortable-adhoc-item.tsx` — `data-tour-id="adhoc-input"` on the Quick List wrapper.
- `src/features/help/components/HelpModal.tsx` — adds the manual **Take the tour** trigger.
- `src/features/wheel/components/winner-modal.tsx` — renders `<PostSpinTip />` once per browser.

## Test plan

- [ ] \`npm run dev\` in incognito → tour auto-starts ~500ms after load
- [ ] Step through all 9 steps; each anchor highlights the correct element
- [ ] Refresh → tour does NOT re-trigger
- [ ] Open Help (\`?\`) → click **Take the tour** → tour restarts, \`product_tour_started\` event has \`source: 'manual'\`
- [ ] Click Skip mid-tour → \`product_tour_skipped\` fires with the current \`step_id\`; flag still set so no nag on reload
- [ ] First wheel spin → post-spin tip appears in winner modal; second spin → tip is gone
- [ ] Verify in PostHog: \`product_tour_started\`, \`product_tour_step_viewed\`, \`product_tour_completed\` events arrive and \`product_tour_completed_at\` person property is set
- [ ] Toggle Death Mode and re-run the tour manually → popover remains readable against the dark/flames background