### PR TITLE
feat: namespace tour eventing by tour id/name/version

### DIFF
--- a/src/features/help/components/HelpModal.tsx
+++ b/src/features/help/components/HelpModal.tsx
@@ -4,6 +4,7 @@ import { cn } from '@/lib/utils';
 
 import { usePostHog } from 'posthog-js/react';
 import { useTour } from '@/features/tour/use-tour';
+import { MAIN_ONBOARDING_TOUR } from '@/features/tour/tour-steps';
 
 interface HelpModalProps {
     open: boolean;
@@ -18,7 +19,7 @@ export function HelpModal({ open, onOpenChange }: HelpModalProps) {
     const handleTakeTour = () => {
         onOpenChange(false);
         // Allow the modal close animation to finish so anchors are visible/unblocked.
-        setTimeout(() => startTour({ source: 'manual' }), 150);
+        setTimeout(() => startTour({ tour: MAIN_ONBOARDING_TOUR, source: 'manual' }), 150);
     };
 
     return (

--- a/src/features/tour/tour-button.tsx
+++ b/src/features/tour/tour-button.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Compass } from 'lucide-react';
 import { useAppStore } from '@/lib/store';
 import { useTour } from './use-tour';
+import { MAIN_ONBOARDING_TOUR } from './tour-steps';
 
 export function TourButton() {
     const { startTour } = useTour();
@@ -13,7 +14,7 @@ export function TourButton() {
         <Button
             type="button"
             size="sm"
-            onClick={() => startTour({ source: 'manual' })}
+            onClick={() => startTour({ tour: MAIN_ONBOARDING_TOUR, source: 'manual' })}
             title="Take the tour"
             aria-label="Take the tour"
             className={`fixed bottom-4 left-4 z-40 shadow-lg rounded-full pl-3 pr-4 gap-2 ${

--- a/src/features/tour/tour-runner.tsx
+++ b/src/features/tour/tour-runner.tsx
@@ -2,16 +2,17 @@
 
 import { useEffect } from 'react';
 import { useTour } from './use-tour';
+import { MAIN_ONBOARDING_TOUR } from './tour-steps';
 
 export function TourRunner() {
     const { startTour, hasCompletedTour } = useTour();
 
     useEffect(() => {
-        if (hasCompletedTour()) return;
+        if (hasCompletedTour({ tour: MAIN_ONBOARDING_TOUR })) return;
 
         const handle = window.setTimeout(() => {
             if (!document.querySelector('[data-tour-id="app-title"]')) return;
-            startTour({ source: 'auto' });
+            startTour({ tour: MAIN_ONBOARDING_TOUR, source: 'auto' });
         }, 500);
 
         return () => window.clearTimeout(handle);

--- a/src/features/tour/tour-steps.ts
+++ b/src/features/tour/tour-steps.ts
@@ -7,80 +7,95 @@ export interface TourStep {
     align?: 'start' | 'center' | 'end';
 }
 
-export const TOUR_STEPS: TourStep[] = [
-    {
-        id: 'app-title',
-        selector: '[data-tour-id="app-title"]',
-        title: 'Welcome to Wheel of Names',
-        description: "Let's take 30 seconds to show you around. Use Next and Prev to step through, or Skip to dismiss.",
-        side: 'bottom',
-        align: 'start',
-    },
-    {
-        id: 'spin-button',
-        selector: '[data-tour-id="spin-button"]',
-        title: 'Spin the wheel',
-        description: 'Click SPIN (or press Enter) to pick a random name from the wheel.',
-        side: 'top',
-        align: 'center',
-    },
-    {
-        id: 'team-controller',
-        selector: '[data-tour-id="team-controller"]',
-        title: 'Your lists',
-        description: 'Switch between saved teams and the Quick List here. Drag to reorder; click to select.',
-        side: 'left',
-        align: 'start',
-    },
-    {
-        id: 'new-team-button',
-        selector: '[data-tour-id="new-team-button"]',
-        title: 'Create a team',
-        description: "Click 'New Team' (or press N) to save a group of names you'll spin often.",
-        side: 'left',
-        align: 'center',
-    },
-    {
-        id: 'adhoc-input',
-        selector: '[data-tour-id="adhoc-input"]',
-        title: 'Or paste names ad-hoc',
-        description: 'Type or paste a comma-separated list here for one-off picks — no saving required.',
-        side: 'left',
-        align: 'center',
-    },
-    {
-        id: 'highlander-toggle',
-        selector: '[data-tour-id="highlander-toggle"]',
-        title: 'Highlander Mode',
-        description: 'Elimination round — each spin removes the winner until one remains. There can be only one!',
-        side: 'bottom',
-        align: 'end',
-    },
-    {
-        id: 'death-toggle',
-        selector: '[data-tour-id="death-toggle"]',
-        title: 'Death Mode',
-        description: 'A thematic reskin with flames and skulls. (Mutually exclusive with Highlander.)',
-        side: 'bottom',
-        align: 'end',
-    },
-    {
-        id: 'settings-button',
-        selector: '[data-tour-id="settings-button"]',
-        title: 'Settings',
-        description: 'Backup & restore your teams, manage integrations, and override feature flags.',
-        side: 'bottom',
-        align: 'end',
-    },
-    {
-        id: 'help-button',
-        selector: '[data-tour-id="help-button"]',
-        title: 'Help is always here',
-        description: 'Press ? or click this button anytime to see keyboard shortcuts and re-run this tour.',
-        side: 'bottom',
-        align: 'end',
-    },
-];
+export interface Tour {
+    id: string;
+    name: string;
+    version: string;
+    steps: TourStep[];
+}
 
-export const TOUR_COMPLETED_KEY = 'wot_tour_completed_v1';
+export const MAIN_ONBOARDING_TOUR: Tour = {
+    id: 'main_onboarding',
+    name: 'Main onboarding',
+    version: 'v1',
+    steps: [
+        {
+            id: 'app-title',
+            selector: '[data-tour-id="app-title"]',
+            title: 'Welcome to Wheel of Names',
+            description: "Let's take 30 seconds to show you around. Use Next and Prev to step through, or Skip to dismiss.",
+            side: 'bottom',
+            align: 'start',
+        },
+        {
+            id: 'spin-button',
+            selector: '[data-tour-id="spin-button"]',
+            title: 'Spin the wheel',
+            description: 'Click SPIN (or press Enter) to pick a random name from the wheel.',
+            side: 'top',
+            align: 'center',
+        },
+        {
+            id: 'team-controller',
+            selector: '[data-tour-id="team-controller"]',
+            title: 'Your lists',
+            description: 'Switch between saved teams and the Quick List here. Drag to reorder; click to select.',
+            side: 'left',
+            align: 'start',
+        },
+        {
+            id: 'new-team-button',
+            selector: '[data-tour-id="new-team-button"]',
+            title: 'Create a team',
+            description: "Click 'New Team' (or press N) to save a group of names you'll spin often.",
+            side: 'left',
+            align: 'center',
+        },
+        {
+            id: 'adhoc-input',
+            selector: '[data-tour-id="adhoc-input"]',
+            title: 'Or paste names ad-hoc',
+            description: 'Type or paste a comma-separated list here for one-off picks — no saving required.',
+            side: 'left',
+            align: 'center',
+        },
+        {
+            id: 'highlander-toggle',
+            selector: '[data-tour-id="highlander-toggle"]',
+            title: 'Highlander Mode',
+            description: 'Elimination round — each spin removes the winner until one remains. There can be only one!',
+            side: 'bottom',
+            align: 'end',
+        },
+        {
+            id: 'death-toggle',
+            selector: '[data-tour-id="death-toggle"]',
+            title: 'Death Mode',
+            description: 'A thematic reskin with flames and skulls. (Mutually exclusive with Highlander.)',
+            side: 'bottom',
+            align: 'end',
+        },
+        {
+            id: 'settings-button',
+            selector: '[data-tour-id="settings-button"]',
+            title: 'Settings',
+            description: 'Backup & restore your teams, manage integrations, and override feature flags.',
+            side: 'bottom',
+            align: 'end',
+        },
+        {
+            id: 'help-button',
+            selector: '[data-tour-id="help-button"]',
+            title: 'Help is always here',
+            description: 'Press ? or click this button anytime to see keyboard shortcuts and re-run this tour.',
+            side: 'bottom',
+            align: 'end',
+        },
+    ],
+};
+
+export function tourCompletedKey(tour: Tour): string {
+    return `wot_tour_${tour.id}_completed_${tour.version}`;
+}
+
 export const POST_SPIN_TIP_KEY = 'wot_post_spin_tip_seen_v1';

--- a/src/features/tour/use-tour.ts
+++ b/src/features/tour/use-tour.ts
@@ -3,47 +3,62 @@
 import { useCallback, useRef } from 'react';
 import { driver, type Driver, type DriveStep } from 'driver.js';
 import { usePostHog } from 'posthog-js/react';
-import { TOUR_STEPS, TOUR_COMPLETED_KEY } from './tour-steps';
+import { type Tour, tourCompletedKey } from './tour-steps';
 
 export type TourSource = 'auto' | 'manual';
 
 interface StartTourOptions {
+    tour: Tour;
     source: TourSource;
+}
+
+interface HasCompletedOptions {
+    tour: Tour;
 }
 
 interface UseTourReturn {
     startTour: (options: StartTourOptions) => void;
-    hasCompletedTour: () => boolean;
+    hasCompletedTour: (options: HasCompletedOptions) => boolean;
 }
 
 export function useTour(): UseTourReturn {
     const posthog = usePostHog();
     const driverRef = useRef<Driver | null>(null);
+    const tourRef = useRef<Tour | null>(null);
     const sourceRef = useRef<TourSource>('auto');
     const startedAtRef = useRef<number>(0);
     const skippedRef = useRef<boolean>(false);
     const lastStepIdRef = useRef<string>('');
 
-    const hasCompletedTour = useCallback(() => {
+    const hasCompletedTour = useCallback(({ tour }: HasCompletedOptions) => {
         if (typeof window === 'undefined') return true;
-        return window.localStorage.getItem(TOUR_COMPLETED_KEY) === '1';
+        return window.localStorage.getItem(tourCompletedKey(tour)) === '1';
     }, []);
 
-    const markCompleted = useCallback(() => {
+    const markCompleted = useCallback((tour: Tour) => {
         if (typeof window !== 'undefined') {
-            window.localStorage.setItem(TOUR_COMPLETED_KEY, '1');
+            window.localStorage.setItem(tourCompletedKey(tour), '1');
         }
     }, []);
 
-    const startTour = useCallback(({ source }: StartTourOptions) => {
+    const baseEventProps = (tour: Tour) => ({
+        tour_id: tour.id,
+        tour_name: tour.name,
+        tour_version: tour.version,
+        total_steps: tour.steps.length,
+        source: sourceRef.current,
+    });
+
+    const startTour = useCallback(({ tour, source }: StartTourOptions) => {
         if (driverRef.current?.isActive()) return;
 
+        tourRef.current = tour;
         sourceRef.current = source;
         startedAtRef.current = Date.now();
         skippedRef.current = false;
-        lastStepIdRef.current = TOUR_STEPS[0]?.id ?? '';
+        lastStepIdRef.current = tour.steps[0]?.id ?? '';
 
-        const steps: DriveStep[] = TOUR_STEPS.map((step) => ({
+        const steps: DriveStep[] = tour.steps.map((step) => ({
             element: step.selector,
             popover: {
                 title: step.title,
@@ -64,42 +79,51 @@ export function useTour(): UseTourReturn {
             prevBtnText: 'Back',
             doneBtnText: 'Done',
             steps,
-            onHighlightStarted: (_el, step, { driver: d }) => {
+            onHighlightStarted: (_el, _step, { driver: d }) => {
+                const activeTour = tourRef.current;
+                if (!activeTour) return;
                 const index = d.getActiveIndex() ?? 0;
-                const stepConfig = TOUR_STEPS[index];
+                const stepConfig = activeTour.steps[index];
                 if (!stepConfig) return;
                 lastStepIdRef.current = stepConfig.id;
                 posthog.capture('product_tour_step_viewed', {
+                    ...baseEventProps(activeTour),
                     step_id: stepConfig.id,
                     step_index: index,
-                    total_steps: TOUR_STEPS.length,
-                    source: sourceRef.current,
                 });
             },
             onCloseClick: (_el, _step, { driver: d }) => {
+                const activeTour = tourRef.current;
+                if (!activeTour) {
+                    d.destroy();
+                    return;
+                }
                 skippedRef.current = true;
                 const index = d.getActiveIndex() ?? 0;
-                const stepConfig = TOUR_STEPS[index];
+                const stepConfig = activeTour.steps[index];
                 posthog.capture('product_tour_skipped', {
+                    ...baseEventProps(activeTour),
                     step_id: stepConfig?.id ?? lastStepIdRef.current,
                     step_index: index,
-                    total_steps: TOUR_STEPS.length,
-                    source: sourceRef.current,
                 });
                 d.destroy();
             },
             onDestroyed: () => {
-                markCompleted();
+                const activeTour = tourRef.current;
+                if (!activeTour) return;
+                markCompleted(activeTour);
                 if (!skippedRef.current) {
                     const completedAt = new Date().toISOString();
                     posthog.capture('product_tour_completed', {
-                        source: sourceRef.current,
+                        ...baseEventProps(activeTour),
                         duration_ms: Date.now() - startedAtRef.current,
-                        total_steps: TOUR_STEPS.length,
                     });
                     posthog.setPersonProperties?.({
-                        product_tour_completed_at: completedAt,
-                        product_tour_completed_source: sourceRef.current,
+                        [`tour_${activeTour.id}_completed_at`]: completedAt,
+                        [`tour_${activeTour.id}_completed_source`]: sourceRef.current,
+                        [`tour_${activeTour.id}_completed_version`]: activeTour.version,
+                        last_tour_completed_id: activeTour.id,
+                        last_tour_completed_at: completedAt,
                     });
                 }
             },
@@ -107,10 +131,7 @@ export function useTour(): UseTourReturn {
 
         driverRef.current = instance;
 
-        posthog.capture('product_tour_started', {
-            source,
-            total_steps: TOUR_STEPS.length,
-        });
+        posthog.capture('product_tour_started', baseEventProps(tour));
 
         instance.drive();
     }, [posthog, markCompleted]);


### PR DESCRIPTION
## Summary

Stacked on top of #11. Makes the tour eventing multi-tour-safe — each tour is a first-class entity with an explicit \`id\`, \`name\`, and \`version\`, and all PostHog events / person properties are namespaced accordingly.

## Why

In the original PR the person properties (\`product_tour_completed_at\`, \`product_tour_completed_source\`) and the localStorage gate (\`wot_tour_completed_v1\`) were global. Adding a second tour later (e.g. a "new feature X" walkthrough) would clobber the first tour's completion record and re-trigger it on users who had already completed it.

## What changed

- \`tour-steps.ts\` — new \`Tour\` type (\`id\`, \`name\`, \`version\`, \`steps\`). Exports \`MAIN_ONBOARDING_TOUR\` ('main_onboarding', v1). localStorage key is per-tour via \`tourCompletedKey(tour)\` → \`wot_tour_main_onboarding_completed_v1\`.
- \`use-tour.ts\` — \`startTour({ tour, source })\` and \`hasCompletedTour({ tour })\` now take the tour explicitly.
  - Every event (\`product_tour_started\` / \`_step_viewed\` / \`_completed\` / \`_skipped\`) now includes \`tour_id\`, \`tour_name\`, \`tour_version\`, \`total_steps\`.
  - On completion, person properties are now: \`tour_<id>_completed_at\`, \`tour_<id>_completed_source\`, \`tour_<id>_completed_version\`, plus cross-tour \`last_tour_completed_id\` / \`last_tour_completed_at\`.
- \`tour-runner.tsx\`, \`tour-button.tsx\`, \`HelpModal.tsx\` — all pass \`tour: MAIN_ONBOARDING_TOUR\`.

## Adding a second tour later

\`\`\`ts
export const NEW_FEATURE_TOUR: Tour = {
    id: 'new_feature_x',
    name: 'New feature X walkthrough',
    version: 'v1',
    steps: [...],
};

// somewhere
startTour({ tour: NEW_FEATURE_TOUR, source: 'manual' });
\`\`\`

Events and person properties auto-namespace; cohorts and funnels work per-tour.

## Test plan

- [ ] \`npm run build\` succeeds
- [ ] First visit auto-triggers the main onboarding tour; \`product_tour_started\` event carries \`tour_id: 'main_onboarding'\`, \`tour_version: 'v1'\`
- [ ] Completing the tour sets \`tour_main_onboarding_completed_at\` and \`last_tour_completed_id\` person properties (no more global \`product_tour_completed_at\`)
- [ ] Reload → tour does not re-trigger (per-tour localStorage gate)
- [ ] Clicking the bottom-left **Take the tour** button or the Help-modal trigger fires \`product_tour_started\` with \`source: 'manual'\`
- [ ] Skip mid-tour → \`product_tour_skipped\` carries \`tour_id\` + \`step_id\`