### PR TITLE
feat: add product tour banner and feature carousel

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import localFont from "next/font/local";
 import "./globals.css";
 import "driver.js/dist/driver.css";
 import { PostHogProvider } from "./providers/posthog-provider";
+import { FeatureBanner } from "@/components/feature-banner";
 
 const outfit = Outfit({
   variable: "--font-outfit",
@@ -35,7 +36,10 @@ export default function RootLayout({
       <body
         className={`${outfit.variable} ${inter.variable} ${highlanderFont.variable} antialiased font-sans`}
       >
-        <PostHogProvider>{children}</PostHogProvider>
+        <PostHogProvider>
+          <FeatureBanner />
+          {children}
+        </PostHogProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,9 +14,10 @@ import { usePostHog } from 'posthog-js/react';
 import { RemoteTeamsInitializer } from '@/features/teams/components/remote-teams-initializer';
 import { useWheelSegments } from '@/features/wheel/hooks';
 import { TourRunner } from '@/features/tour/tour-runner';
+import { FeatureCarousel } from '@/components/feature-carousel';
 
 export default function Home() {
-  const { helpOpen, setHelpOpen, adminOpen, setAdminOpen, isHighlanderMode, isDeathMode } = useAppStore();
+  const { helpOpen, setHelpOpen, adminOpen, setAdminOpen, isHighlanderMode, isDeathMode, carouselEnabled } = useAppStore();
   const { segments } = useWheelSegments();
   
   const showHighlanderVictory = isHighlanderMode && segments.length === 1;
@@ -79,6 +80,8 @@ export default function Home() {
             </Button>
           </div>
         </header>
+
+        {carouselEnabled && <FeatureCarousel />}
 
         {/* Main Content Area */}
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-8">

--- a/src/components/feature-banner.tsx
+++ b/src/components/feature-banner.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { usePostHog } from 'posthog-js/react';
+import { X, Sparkles } from 'lucide-react';
+import { useTour } from '@/features/tour/use-tour';
+
+const BANNER_ID = 'product_tours_launch_v1';
+
+export function FeatureBanner() {
+    const posthog = usePostHog();
+    const { startTour } = useTour();
+    const [visible, setVisible] = useState(true);
+
+    useEffect(() => {
+        if (!visible) return;
+        posthog.capture('feature_banner_shown', { banner_id: BANNER_ID });
+    }, [posthog, visible]);
+
+    const handleDismiss = () => {
+        posthog.capture('feature_banner_dismissed', { banner_id: BANNER_ID });
+        setVisible(false);
+    };
+
+    const handleCta = () => {
+        posthog.capture('feature_banner_cta_clicked', { banner_id: BANNER_ID });
+        setVisible(false);
+        startTour({ source: 'manual' });
+    };
+
+    if (!visible) return null;
+
+    return (
+        <div
+            role="region"
+            aria-label="New feature announcement"
+            className="bg-primary text-primary-foreground"
+        >
+            <div className="max-w-6xl mx-auto px-4 py-2 flex items-center gap-3 text-sm">
+                <Sparkles className="h-4 w-4 shrink-0" aria-hidden />
+                <p className="flex-1 leading-snug">
+                    <span className="font-semibold">New:</span> Product tours are here — get a quick guided walkthrough of the wheel.
+                </p>
+                <button
+                    type="button"
+                    onClick={handleCta}
+                    className="underline underline-offset-2 hover:opacity-80 font-medium whitespace-nowrap"
+                >
+                    Take the tour
+                </button>
+                <button
+                    type="button"
+                    onClick={handleDismiss}
+                    aria-label="Dismiss banner"
+                    className="rounded-md p-1 hover:bg-black/10 focus:outline-none focus:ring-2 focus:ring-current"
+                >
+                    <X className="h-4 w-4" />
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/components/feature-carousel.tsx
+++ b/src/components/feature-carousel.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { usePostHog } from 'posthog-js/react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+interface Slide {
+    id: string;
+    title: string;
+    body: string;
+}
+
+const SLIDES: Slide[] = [
+    {
+        id: 'spin',
+        title: 'Spin to pick a winner',
+        body: 'Hit SPIN or press Enter to draw a random name from your list.',
+    },
+    {
+        id: 'teams',
+        title: 'Save your teams',
+        body: 'Group the names you spin often — switch between teams in one click.',
+    },
+    {
+        id: 'highlander',
+        title: 'Highlander Mode',
+        body: 'Eliminate the winner each round until one name remains. There can be only one.',
+    },
+];
+
+export function FeatureCarousel() {
+    const posthog = usePostHog();
+    const [index, setIndex] = useState(0);
+
+    const goTo = useCallback((next: number, source: 'click' | 'keyboard' | 'dot') => {
+        const normalized = ((next % SLIDES.length) + SLIDES.length) % SLIDES.length;
+        setIndex(normalized);
+        const slide = SLIDES[normalized];
+        posthog.capture('feature_carousel_slide_viewed', {
+            slide_number: normalized + 1,
+            slide_id: slide.id,
+            total_slides: SLIDES.length,
+            source,
+        });
+    }, [posthog]);
+
+    useEffect(() => {
+        const slide = SLIDES[0];
+        posthog.capture('feature_carousel_slide_viewed', {
+            slide_number: 1,
+            slide_id: slide.id,
+            total_slides: SLIDES.length,
+            source: 'initial',
+        });
+    }, [posthog]);
+
+    useEffect(() => {
+        const handler = (e: KeyboardEvent) => {
+            const target = e.target as HTMLElement | null;
+            if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) {
+                return;
+            }
+            if (e.key === 'ArrowRight') {
+                goTo(index + 1, 'keyboard');
+            } else if (e.key === 'ArrowLeft') {
+                goTo(index - 1, 'keyboard');
+            }
+        };
+        window.addEventListener('keydown', handler);
+        return () => window.removeEventListener('keydown', handler);
+    }, [goTo, index]);
+
+    const slide = SLIDES[index];
+
+    return (
+        <section
+            aria-label="Feature highlights"
+            aria-roledescription="carousel"
+            className="rounded-[var(--radius)] border-2 border-dashed border-border bg-muted/30 backdrop-blur-sm"
+        >
+            <div className="flex items-stretch">
+                <button
+                    type="button"
+                    onClick={() => goTo(index - 1, 'click')}
+                    aria-label="Previous slide"
+                    className="px-3 flex items-center hover:bg-muted/50 rounded-l-[var(--radius)] focus:outline-none focus:ring-2 focus:ring-ring"
+                >
+                    <ChevronLeft className="h-5 w-5" />
+                </button>
+                <button
+                    type="button"
+                    onClick={() => goTo(index + 1, 'click')}
+                    aria-label="Next slide"
+                    aria-live="polite"
+                    className="flex-1 px-4 py-4 text-left focus:outline-none focus:ring-2 focus:ring-ring rounded-none"
+                >
+                    <h3 className="font-heading text-lg font-semibold leading-tight">{slide.title}</h3>
+                    <p className="text-sm text-muted-foreground mt-1">{slide.body}</p>
+                </button>
+                <button
+                    type="button"
+                    onClick={() => goTo(index + 1, 'click')}
+                    aria-label="Next slide"
+                    className="px-3 flex items-center hover:bg-muted/50 rounded-r-[var(--radius)] focus:outline-none focus:ring-2 focus:ring-ring"
+                >
+                    <ChevronRight className="h-5 w-5" />
+                </button>
+            </div>
+            <div className="flex justify-center gap-2 pb-3" role="tablist" aria-label="Slide navigation">
+                {SLIDES.map((s, i) => (
+                    <button
+                        key={s.id}
+                        type="button"
+                        role="tab"
+                        aria-selected={i === index}
+                        aria-label={`Go to slide ${i + 1}`}
+                        onClick={() => goTo(i, 'dot')}
+                        className={`h-2 w-2 rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-ring ${i === index ? 'bg-foreground' : 'bg-muted-foreground/40 hover:bg-muted-foreground/70'}`}
+                    />
+                ))}
+            </div>
+        </section>
+    );
+}

--- a/src/features/admin/components/admin-modal.tsx
+++ b/src/features/admin/components/admin-modal.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { useAppStore } from "@/lib/store";
-import { Database, Bug, Download, Upload, Globe, Cloud } from "lucide-react";
+import { Database, Bug, Download, Upload, Globe, Cloud, LayoutGrid } from "lucide-react";
 import { downloadBackup } from "../services/export-service";
 import { importData } from "../services/import-service";
 import { usePostHog } from 'posthog-js/react';
@@ -19,7 +19,7 @@ interface AdminModalProps {
 
 export function AdminModal({ open, onOpenChange }: AdminModalProps) {
     const fileInputRef = useRef<HTMLInputElement>(null);
-    const { verboseLogging, setVerboseLogging } = useAppStore();
+    const { verboseLogging, setVerboseLogging, carouselEnabled, setCarouselEnabled } = useAppStore();
     const posthog = usePostHog();
     const [remoteTeamsEnabled, setRemoteTeamsEnabled] = useState(false);
     const [importModalOpen, setImportModalOpen] = useState(false);
@@ -165,6 +165,21 @@ export function AdminModal({ open, onOpenChange }: AdminModalProps) {
                                     <p className={styles['admin-modal__card-desc']}>Enable syncing ephemeral teams from remote configuration.</p>
                                 </div>
                                 <Switch checked={remoteTeamsEnabled} onCheckedChange={handleToggleRemoteTeams} />
+                            </div>
+                        </div>
+
+                        {/* Display Section */}
+                        <div className={styles['admin-modal__section']}>
+                            <h3 className={styles['admin-modal__section-title']}>
+                                <LayoutGrid className="h-5 w-5" />
+                                Display
+                            </h3>
+                            <div className={cn(styles['admin-modal__card'], styles['admin-modal__card--row'])}>
+                                <div className={styles['admin-modal__card-header']}>
+                                    <h4 className={styles['admin-modal__card-title']}>Feature Carousel</h4>
+                                    <p className={styles['admin-modal__card-desc']}>Show the rotating feature highlights above the wheel.</p>
+                                </div>
+                                <Switch checked={carouselEnabled} onCheckedChange={setCarouselEnabled} />
                             </div>
                         </div>
 

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -55,6 +55,10 @@ interface AppState {
     // Debug State
     verboseLogging: boolean;
     setVerboseLogging: (enabled: boolean) => void;
+
+    // Display
+    carouselEnabled: boolean;
+    setCarouselEnabled: (enabled: boolean) => void;
 }
 
 export const useAppStore = create<AppState>()(
@@ -214,6 +218,10 @@ export const useAppStore = create<AppState>()(
             // Debug State
             verboseLogging: false,
             setVerboseLogging: (enabled) => set({ verboseLogging: enabled }),
+
+            // Display
+            carouselEnabled: true,
+            setCarouselEnabled: (enabled) => set({ carouselEnabled: enabled }),
         }),
         {
             name: 'wheel-of-names-storage',
@@ -226,7 +234,8 @@ export const useAppStore = create<AppState>()(
                 adHocOrder: state.adHocOrder,
                 isHighlanderMode: state.isHighlanderMode,
                 isDeathMode: state.isDeathMode,
-                verboseLogging: state.verboseLogging // Persist debug setting
+                verboseLogging: state.verboseLogging, // Persist debug setting
+                carouselEnabled: state.carouselEnabled,
             }), // Don't persist transient states like isSpinning
         }
     )


### PR DESCRIPTION
## Summary
- New top-of-page **announcement banner** introducing product tours, with a "Take the tour" CTA wired to the existing `useTour` hook. Visibility is in-memory React state, so it reappears on every fresh page load and dismiss only lasts for the current view.
- New **3-slide feature carousel** above the wheel. Click anywhere on the slide body or the chevrons to advance, `ArrowLeft` / `ArrowRight` rotate slides (suppressed while typing in inputs), and dots jump directly to a slide. Wraps at both ends.
- New **"Feature Carousel" toggle** in the admin modal's Display section, backed by a new `carouselEnabled` field in the Zustand store (persisted, default on).

## PostHog instrumentation
- `feature_banner_shown` / `feature_banner_dismissed` / `feature_banner_cta_clicked` — all tagged with `banner_id: 'product_tours_launch_v1'`.
- `feature_carousel_slide_viewed` — fires on every slide view with:
  - `slide_number` (1-indexed)
  - `slide_id` (stable string)
  - `total_slides`
  - `source` (`initial` | `click` | `keyboard` | `dot`) so engagement can be broken down by interaction type.

## Test plan
- [ ] Banner renders at the top of the page on every reload; dismiss hides it for the current view only
- [ ] Clicking "Take the tour" launches the driver.js tour
- [ ] Carousel renders above the wheel by default; toggling "Feature Carousel" in Settings hides/shows it and the choice persists across reloads
- [ ] Left/Right arrow keys rotate slides; dots jump directly; wrap-around works in both directions
- [ ] Arrow keys do not rotate slides while typing in the ad-hoc input
- [ ] Confirm the four PostHog events arrive with the expected properties (especially `slide_number` and `source`)