### PR TITLE
feat(carousel): add per-slide Click me button with click tracking

### DIFF
--- a/src/components/feature-carousel.tsx
+++ b/src/components/feature-carousel.tsx
@@ -44,6 +44,15 @@ export function FeatureCarousel() {
         });
     }, [posthog]);
 
+    const handleSlideClick = useCallback((slideIndex: number) => {
+        const slide = SLIDES[slideIndex];
+        posthog.capture('feature_carousel_slide_clicked', {
+            slide_number: slideIndex + 1,
+            slide_id: slide.id,
+            total_slides: SLIDES.length,
+        });
+    }, [posthog]);
+
     useEffect(() => {
         const slide = SLIDES[0];
         posthog.capture('feature_carousel_slide_viewed', {
@@ -87,16 +96,22 @@ export function FeatureCarousel() {
                 >
                     <ChevronLeft className="h-5 w-5" />
                 </button>
-                <button
-                    type="button"
-                    onClick={() => goTo(index + 1, 'click')}
-                    aria-label="Next slide"
+                <div
                     aria-live="polite"
-                    className="flex-1 px-4 py-4 text-left focus:outline-none focus:ring-2 focus:ring-ring rounded-none"
+                    className="flex-1 px-4 py-4 flex items-center gap-4"
                 >
-                    <h3 className="font-heading text-lg font-semibold leading-tight">{slide.title}</h3>
-                    <p className="text-sm text-muted-foreground mt-1">{slide.body}</p>
-                </button>
+                    <div className="flex-1">
+                        <h3 className="font-heading text-lg font-semibold leading-tight">{slide.title}</h3>
+                        <p className="text-sm text-muted-foreground mt-1">{slide.body}</p>
+                    </div>
+                    <button
+                        type="button"
+                        onClick={() => handleSlideClick(index)}
+                        className="shrink-0 px-3 py-1.5 text-sm font-medium rounded-md bg-primary text-primary-foreground hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-ring"
+                    >
+                        Click me
+                    </button>
+                </div>
                 <button
                     type="button"
                     onClick={() => goTo(index + 1, 'click')}


### PR DESCRIPTION
Stacked on top of #13.

## Summary
- Add a primary-colored **"Click me"** button to every carousel slide.
- Clicking it captures a new `feature_carousel_slide_clicked` PostHog event with `slide_number` (1-indexed), `slide_id`, and `total_slides` — same keys as `feature_carousel_slide_viewed` so you can join views and clicks by slide.
- Mirrors the merchant-ad carousel pattern: every view and every click can be attributed back to the slide ("merchant") that was shown.

## Side effect
The slide body is no longer a clickable advance target (HTML doesn't allow nesting a button inside a button). Slide navigation stays on:
- Left/right chevrons
- Dot indicators below
- `ArrowLeft` / `ArrowRight` keys

If you'd rather keep advance-on-body-click, easy to restore — let me know and I'll switch to `stopPropagation` on the CTA.

## Test plan
- [ ] Each slide shows a "Click me" button
- [ ] Clicking it does **not** advance the carousel
- [ ] PostHog receives `feature_carousel_slide_clicked` with the correct `slide_number` and `slide_id` for whichever slide is visible
- [ ] Slide nav via chevrons / dots / arrow keys still works and still fires `feature_carousel_slide_viewed`